### PR TITLE
Rollen-Modell

### DIFF
--- a/app/controllers/abrechnung_controller.rb
+++ b/app/controllers/abrechnung_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class AbrechnungController < ApplicationController
+  before_action :require_abrechnung_access
+
   def index
     redirect_to action: "jahresstatistik"
   end
@@ -25,6 +27,10 @@ class AbrechnungController < ApplicationController
   end
 
   private
+
+  def require_abrechnung_access
+    deny_access if current_user.external?
+  end
 
   def respond_to_html_and_excel(filename)
     respond_to do |format|

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -1,10 +1,8 @@
 # frozen_string_literal: true
 
 class ApplicationController < ActionController::Base
-  # Every authenticated user has full access. Role-based authorization was a
-  # deliberate non-goal: the user base is a small, trusted family. Add roles
-  # here (e.g. restricting user management to Miteigentuemer) if that changes.
   include Authentication
+  include Authorization
 
   layout "reservation"
 

--- a/app/controllers/concerns/authorization.rb
+++ b/app/controllers/concerns/authorization.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+module Authorization
+  extend ActiveSupport::Concern
+
+  private
+
+  def deny_access
+    flash[:notice] = "Dazu hast du keine Berechtigung."
+    redirect_to root_path
+  end
+
+  def require_owner
+    deny_access unless current_user.owner?
+  end
+end

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -83,14 +83,11 @@ class ReservationsController < ApplicationController
   private
 
   def require_reservation_manager
-    deny_access unless current_user.owner? || current_user.member?
+    deny_access unless current_user.may_reserve?
   end
 
-  # Owners may act on any reservation; members only on their own.
   def require_own_reservation
-    return if current_user.owner?
-
-    deny_access unless Reservation.find(params.expect(:id)).user_id == current_user.id
+    deny_access unless Reservation.find(params.expect(:id)).editable_by?(current_user)
   end
 
   def set_user_options

--- a/app/controllers/reservations_controller.rb
+++ b/app/controllers/reservations_controller.rb
@@ -1,6 +1,8 @@
 # frozen_string_literal: true
 
 class ReservationsController < ApplicationController
+  before_action :require_reservation_manager, only: %i[new create edit update destroy]
+  before_action :require_own_reservation, only: %i[edit update destroy]
   before_action :set_user_options, only: %i[new create edit update]
 
   def index
@@ -80,8 +82,20 @@ class ReservationsController < ApplicationController
 
   private
 
+  def require_reservation_manager
+    deny_access unless current_user.owner? || current_user.member?
+  end
+
+  # Owners may act on any reservation; members only on their own.
+  def require_own_reservation
+    return if current_user.owner?
+
+    deny_access unless Reservation.find(params.expect(:id)).user_id == current_user.id
+  end
+
   def set_user_options
-    @users = User.all.sort.map { |user| [ user.name, user.id ] }
+    users = current_user.owner? ? User.all.sort : [ current_user ]
+    @users = users.map { |user| [ user.name, user.id ] }
   end
 
   def month_and_year_as_time(string)
@@ -92,7 +106,10 @@ class ReservationsController < ApplicationController
   end
 
   def reservation_params
-    params.fetch(:reservation, {}).permit(:user_id, :start, :finish, :type_of_reservation, :is_exclusive, :comment)
+    permitted = params.fetch(:reservation, {}).permit(:user_id, :start, :finish, :type_of_reservation, :is_exclusive,
+                                                      :comment)
+    permitted[:user_id] = current_user.id unless current_user.owner?
+    permitted
   end
 
   def parse_date_param

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -1,6 +1,10 @@
 # frozen_string_literal: true
 
 class UsersController < ApplicationController
+  before_action :require_user_reader, only: :index
+  before_action :require_owner, only: %i[new create destroy]
+  before_action :require_owner_or_self, only: %i[edit update]
+
   def index
     @all_users = User.all.sort
   end
@@ -15,6 +19,7 @@ class UsersController < ApplicationController
 
   def create
     @user = User.new(user_params)
+    apply_role(@user)
     if @user.save
       flash[:notice] = "Benutzer #{@user.name} erstellt"
       redirect_to users_path
@@ -26,6 +31,7 @@ class UsersController < ApplicationController
 
   def update
     @user = User.find(params.expect(:id))
+    apply_role(@user)
     if @user.update(user_update_params)
       flash[:notice] = "Benutzer-Angaben gespeichert."
       redirect_to users_path
@@ -46,8 +52,29 @@ class UsersController < ApplicationController
 
   private
 
+  def require_user_reader
+    deny_access if current_user.external?
+  end
+
+  # Owners manage anyone; everyone else may only touch their own account, and
+  # the shared house account has no self-service at all.
+  def require_owner_or_self
+    return if current_user.owner?
+
+    deny_access if current_user.shared_account? || current_user.id != params.expect(:id).to_i
+  end
+
   def user_params
     params.fetch(:user, {}).permit(:name, :email, :telefon, :miteigentuemer, :password, :password_confirmation)
+  end
+
+  # Role is assigned explicitly (never mass-assigned) and only by owners; a
+  # role submitted by anyone else is ignored.
+  def apply_role(user)
+    return unless current_user.owner?
+
+    role = params.dig(:user, :role)
+    user.role = role if role.present?
   end
 
   # On edit, blank password fields mean "keep the current password".

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -65,7 +65,7 @@ class UsersController < ApplicationController
   end
 
   def user_params
-    params.fetch(:user, {}).permit(:name, :email, :telefon, :miteigentuemer, :password, :password_confirmation)
+    params.fetch(:user, {}).permit(:name, :email, :telefon, :password, :password_confirmation)
   end
 
   # Role is assigned explicitly (never mass-assigned) and only by owners; a

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -77,7 +77,7 @@ class Reservation < ApplicationRecord
       type: classified_type,
       blocks: duration_in_8_hour_blocks,
       days: duration_in_days,
-      miteigentuemer: user.miteigentuemer?,
+      owner: user.owner?,
       exclusive: is_exclusive?
     )
   end

--- a/app/models/reservation.rb
+++ b/app/models/reservation.rb
@@ -72,6 +72,10 @@ class Reservation < ApplicationRecord
     billing.fee
   end
 
+  def editable_by?(user)
+    user.owner? || user_id == user.id
+  end
+
   def billing
     ReservationBilling.new(
       type: classified_type,

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -72,6 +72,10 @@ class User < ApplicationRecord
     ROLE_LABELS.fetch(role)
   end
 
+  def may_reserve?
+    owner? || member?
+  end
+
   def self.authenticate(login, password)
     user = find_by(name: login) || find_by(email: login)
     return nil unless user

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,7 +8,6 @@
 #  email                  :string(255)
 #  has_to_change_password :boolean
 #  hashed_password        :string(255)
-#  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
 #  role                   :string(255)      default("member"), not null
@@ -37,8 +36,8 @@ class User < ApplicationRecord
     "shared_account" => "Haus-Login"
   }.freeze
 
-  # external is only assignable once the responsible_user flow exists
-  # (Vorhaben #5); until then it is not offered as a selectable role.
+  # external is only assignable once externals can be created together with
+  # their responsible owner; until then it is not offered as a selectable role.
   ASSIGNABLE_ROLE_LABELS = ROLE_LABELS.except("external").freeze
 
   enum :role, ROLE_LABELS.keys.index_with(&:itself), default: "member"

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -37,6 +37,10 @@ class User < ApplicationRecord
     "shared_account" => "Haus-Login"
   }.freeze
 
+  # external is only assignable once the responsible_user flow exists
+  # (Vorhaben #5); until then it is not offered as a selectable role.
+  ASSIGNABLE_ROLE_LABELS = ROLE_LABELS.except("external").freeze
+
   enum :role, ROLE_LABELS.keys.index_with(&:itself), default: "member"
 
   has_many :reservations, dependent: :restrict_with_error

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -11,20 +11,39 @@
 #  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
+#  role                   :string(255)      default("member"), not null
 #  salt                   :string(255)
 #  telefon                :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  responsible_user_id    :bigint
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
-#  index_users_on_name   (name) UNIQUE
+#  index_users_on_email                (email) UNIQUE
+#  index_users_on_name                 (name) UNIQUE
+#  index_users_on_responsible_user_id  (responsible_user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (responsible_user_id => users.id)
 #
 
 class User < ApplicationRecord
+  ROLE_LABELS = {
+    "owner" => "Miteigentümer/in",
+    "member" => "Nutzungsberechtigte/r",
+    "external" => "Externe/r",
+    "shared_account" => "Haus-Login"
+  }.freeze
+
+  enum :role, ROLE_LABELS.keys.index_with(&:itself), default: "member"
+
   has_many :reservations, dependent: :restrict_with_error
   has_many :sessions, dependent: :destroy
+  has_many :dependents, class_name: "User", foreign_key: :responsible_user_id,
+                        inverse_of: :responsible_user, dependent: :restrict_with_error
+  belongs_to :responsible_user, class_name: "User", optional: true
 
   # validations: false because the built-in digest-presence check rejects
   # legacy users (bcrypt not set yet, only a SHA1 hash). We validate the
@@ -36,11 +55,18 @@ class User < ApplicationRecord
   validates :name, :email, presence: true
   validates :password, confirmation: true, allow_blank: true
   validate :password_must_be_set
+  validates :responsible_user, presence: true, if: :external?
+  validates :responsible_user, absence: true, unless: :external?
+  validate :responsible_user_must_be_owner
 
   before_save :clear_legacy_password, if: -> { password_digest_changed? && password_digest.present? }
 
   def <=>(other)
     name <=> other.name
+  end
+
+  def role_label
+    ROLE_LABELS.fetch(role)
   end
 
   def self.authenticate(login, password)
@@ -73,6 +99,12 @@ class User < ApplicationRecord
     return if password_digest.present? || hashed_password.present?
 
     errors.add(:password, :blank)
+  end
+
+  def responsible_user_must_be_owner
+    return if responsible_user.blank?
+
+    errors.add(:responsible_user, :invalid) unless responsible_user.owner?
   end
 
   def clear_legacy_password

--- a/app/services/reservation_billing.rb
+++ b/app/services/reservation_billing.rb
@@ -4,19 +4,19 @@ class ReservationBilling
   RATE_PER_BLOCK = 15
   FLAT_GROSSANLASS = 200
   RATE_PER_DAY_EXTERN = 100
-  FREE_BLOCKS_MITEIGENTUEMER = 6
+  FREE_BLOCKS_OWNER = 6
 
-  def initialize(type:, blocks:, days:, miteigentuemer:, exclusive:)
+  def initialize(type:, blocks:, days:, owner:, exclusive:)
     @type = type
     @blocks = blocks
     @days = days
-    @miteigentuemer = miteigentuemer
+    @owner = owner
     @exclusive = exclusive
   end
 
   def paid_blocks
-    if @miteigentuemer && !@exclusive
-      [ @blocks - FREE_BLOCKS_MITEIGENTUEMER, 0 ].max
+    if @owner && !@exclusive
+      [ @blocks - FREE_BLOCKS_OWNER, 0 ].max
     else
       @blocks
     end

--- a/app/views/reservations/show.html.erb
+++ b/app/views/reservations/show.html.erb
@@ -1,1 +1,1 @@
-<%= render partial: @reservation§ %>
+<%= render partial: @reservation %>

--- a/app/views/users/edit.html.erb
+++ b/app/views/users/edit.html.erb
@@ -19,10 +19,12 @@
         <td class="legend">Name:</td>
         <td class="data"><%= form.text_field :name, size: 40 %></td>
       </tr>
+      <% if current_user.owner? %>
       <tr>
-        <td class="legend">MiteigentümerIn:</td>
-        <td class="data"><%= form.check_box :miteigentuemer %></td>
+        <td class="legend">Rolle:</td>
+        <td class="data"><%= form.select(:role, User::ASSIGNABLE_ROLE_LABELS.map { |key, label| [ label, key ] }) %></td>
       </tr>
+      <% end %>
       <tr>
         <td class="legend">eMail:</td>
         <td class="data"><%= form.text_field :email, size: 40 %></td>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -2,7 +2,7 @@
 <ul>
   <% for user in @all_users %>
     <li>
-      <%= h(user.name) %> 	(<%= mail_to user.email %>, <%= user.telefon %>)
+      <%= h(user.name) %> 	(<%= user.role_label %>, <%= mail_to user.email %>, <%= user.telefon %>)
       <small><i>
       <%= link_to "[Bearbeiten]", edit_user_path(user) %>
       <%= link_to "[Löschen]", user_path(user), data: { turbo_method: :delete, turbo_confirm: "#{user.name} wirklich löschen?" } %>

--- a/app/views/users/new.html.erb
+++ b/app/views/users/new.html.erb
@@ -20,8 +20,8 @@
         <td class="data"><%= form.text_field :name, size: 40 %></td>
       </tr>
       <tr>
-        <td class="legend">MiteigentümerIn:</td>
-        <td class="data"><%= form.check_box :miteigentuemer %></td>
+        <td class="legend">Rolle:</td>
+        <td class="data"><%= form.select(:role, User::ASSIGNABLE_ROLE_LABELS.map { |key, label| [ label, key ] }) %></td>
       </tr>
       <tr>
         <td class="legend">eMail:</td>

--- a/db/migrate/20260614120000_add_role_to_users.rb
+++ b/db/migrate/20260614120000_add_role_to_users.rb
@@ -1,0 +1,17 @@
+# frozen_string_literal: true
+
+class AddRoleToUsers < ActiveRecord::Migration[8.1]
+  def up
+    add_column :users, :role, :string, null: false, default: "member"
+    add_reference :users, :responsible_user, foreign_key: { to_table: :users }, null: true
+
+    # Carry the existing Miteigentuemer flag over into the new role. Everyone
+    # else (false / NULL) keeps the column default "member".
+    execute "UPDATE users SET role = 'owner' WHERE miteigentuemer = TRUE"
+  end
+
+  def down
+    remove_reference :users, :responsible_user, foreign_key: { to_table: :users }
+    remove_column :users, :role
+  end
+end

--- a/db/migrate/20260614130000_remove_miteigentuemer_from_users.rb
+++ b/db/migrate/20260614130000_remove_miteigentuemer_from_users.rb
@@ -1,0 +1,7 @@
+# frozen_string_literal: true
+
+class RemoveMiteigentuemerFromUsers < ActiveRecord::Migration[8.1]
+  def change
+    remove_column :users, :miteigentuemer, :boolean
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_05_140000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -68,15 +68,19 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_05_140000) do
     t.boolean "miteigentuemer"
     t.string "name"
     t.string "password_digest"
+    t.bigint "responsible_user_id"
+    t.string "role", default: "member", null: false
     t.string "salt"
     t.string "telefon"
     t.datetime "updated_at", null: false
     t.index ["email"], name: "index_users_on_email", unique: true
     t.index ["name"], name: "index_users_on_name", unique: true
+    t.index ["responsible_user_id"], name: "index_users_on_responsible_user_id"
   end
 
   add_foreign_key "active_storage_attachments", "active_storage_blobs", column: "blob_id"
   add_foreign_key "active_storage_variant_records", "active_storage_blobs", column: "blob_id"
   add_foreign_key "reservations", "users"
   add_foreign_key "sessions", "users"
+  add_foreign_key "users", "users", column: "responsible_user_id"
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
+ActiveRecord::Schema[8.1].define(version: 2026_06_14_130000) do
   create_table "active_storage_attachments", charset: "utf8mb4", collation: "utf8mb4_uca1400_ai_ci", force: :cascade do |t|
     t.bigint "blob_id", null: false
     t.datetime "created_at", null: false
@@ -65,7 +65,6 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_14_120000) do
     t.string "email"
     t.boolean "has_to_change_password"
     t.string "hashed_password"
-    t.boolean "miteigentuemer"
     t.string "name"
     t.string "password_digest"
     t.bigint "responsible_user_id"

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -17,14 +17,14 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "new renders the form" do
-    login_as_user
+    login_as_owner
     get new_user_path
 
     assert_response :success
   end
 
   test "create with invalid params re-renders the form" do
-    login_as_user
+    login_as_owner
     post users_path, params: { user: { name: "NoMail", password: "Password" } }
 
     assert_response :unprocessable_entity
@@ -32,7 +32,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create adds a user that can then log in" do
-    login_as_user
+    login_as_owner
     post users_path, params: { user: { name: "ACB", email: "acb@example.com", password: "Password" } }
 
     assert_redirected_to users_path
@@ -42,7 +42,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "create persists miteigentuemer and telefon" do
-    login_as_user
+    login_as_owner
     post users_path, params: { user: { name: "Owner", email: "owner@example.com", telefon: "079", miteigentuemer: "1", password: "Password" } }
     owner = User.find_by(name: "Owner")
 
@@ -51,7 +51,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "edit renders the form" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "newuser", email: "email@mail.com", password: "password")
     get edit_user_path(user)
 
@@ -59,7 +59,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update changes the user" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "newuser", email: "email@mail.com", password: "password")
     patch user_path(user), params: { user: { name: "NewName", email: "new@example.com", password: "NewPassword" } }
 
@@ -68,7 +68,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update with blank password keeps the existing one" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "newuser", email: "email@mail.com", password: "password")
     patch user_path(user), params: { user: { email: "changed@example.com", password: "", password_confirmation: "" } }
 
@@ -78,7 +78,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "update a legacy user without a bcrypt digest and no new password" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "Legacy", email: "legacy@example.com", password: "temporary")
     user.update_columns(password_digest: nil, salt: "s", hashed_password: User.legacy_hash("oldsecret", "s"))
     patch user_path(user), params: { user: { email: "newmail@example.com", password: "", password_confirmation: "" } }
@@ -88,7 +88,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "destroy removes the user" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "newuser", email: "email@mail.com", password: "password")
     delete user_path(user)
 
@@ -97,7 +97,7 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
   end
 
   test "destroying a user with reservations is rejected gracefully" do
-    login_as_user
+    login_as_owner
     user = create(:user, name: "Owner", password: "password")
     create(:reservation, user: user)
 

--- a/test/controllers/users_controller_test.rb
+++ b/test/controllers/users_controller_test.rb
@@ -41,13 +41,13 @@ class UsersControllerTest < ActionDispatch::IntegrationTest
     assert_redirected_to root_path
   end
 
-  test "create persists miteigentuemer and telefon" do
+  test "create persists role and telefon" do
     login_as_owner
-    post users_path, params: { user: { name: "Owner", email: "owner@example.com", telefon: "079", miteigentuemer: "1", password: "Password" } }
-    owner = User.find_by(name: "Owner")
+    post users_path, params: { user: { name: "Owner", email: "owner@example.com", telefon: "079", role: "owner", password: "Password" } }
+    created = User.find_by(name: "Owner")
 
-    assert_predicate owner, :miteigentuemer
-    assert_equal "079", owner.telefon
+    assert_predicate created, :owner?
+    assert_equal "079", created.telefon
   end
 
   test "edit renders the form" do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -11,15 +11,22 @@
 #  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
+#  role                   :string(255)      default("member"), not null
 #  salt                   :string(255)
 #  telefon                :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  responsible_user_id    :bigint
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
-#  index_users_on_name   (name) UNIQUE
+#  index_users_on_email                (email) UNIQUE
+#  index_users_on_name                 (name) UNIQUE
+#  index_users_on_responsible_user_id  (responsible_user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (responsible_user_id => users.id)
 #
 
 FactoryBot.define do

--- a/test/factories/users.rb
+++ b/test/factories/users.rb
@@ -8,7 +8,6 @@
 #  email                  :string(255)
 #  has_to_change_password :boolean
 #  hashed_password        :string(255)
-#  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
 #  role                   :string(255)      default("member"), not null

--- a/test/integration/role_authorization_test.rb
+++ b/test/integration/role_authorization_test.rb
@@ -2,9 +2,6 @@
 
 require "test_helper"
 
-# Authorization spec for Vorhaben #1 (Rollen-Modell). See roles-spec.local.md
-# §5 for the access matrix this file encodes. A forbidden action redirects to
-# root with a German flash (spec §8, O-2).
 class RoleAuthorizationTest < ActionDispatch::IntegrationTest
   # --- Reservations: viewing is open to all roles ----------------------------
 

--- a/test/integration/role_authorization_test.rb
+++ b/test/integration/role_authorization_test.rb
@@ -3,212 +3,256 @@
 require "test_helper"
 
 # Authorization spec for Vorhaben #1 (Rollen-Modell). See roles-spec.local.md
-# §5 for the access matrix this file encodes.
-#
-# Every test below is commented out so the suite stays green until the role
-# enum and the controller guards are implemented. Activate the relevant block
-# per Feinplanungs-Schritt, then run the broad suite.
-#
-# The expected behaviour for a forbidden action (spec §5, O-2) is a redirect to
-# root with a German flash; the exact wording below is illustrative and gets
-# pinned when the guard is built.
+# §5 for the access matrix this file encodes. A forbidden action redirects to
+# root with a German flash (spec §8, O-2).
 class RoleAuthorizationTest < ActionDispatch::IntegrationTest
-  # def sign_in_as(role)
-  #   user = create(:user, role: role, password: "password")
-  #   post session_path, params: { name: user.name, password: "password" }
-  #   user
-  # end
-
-  # def reservation_attrs(user, overrides = {})
-  #   {
-  #     user_id: user.id,
-  #     start: at("2019-03-01 14:00"),
-  #     finish: at("2019-03-01 18:00"),
-  #     type_of_reservation: Reservation::KURZAUFENTHALT,
-  #     is_exclusive: true,
-  #     comment: ""
-  #   }.merge(overrides)
-  # end
-
-  # def assert_forbidden
-  #   assert_redirected_to root_path
-  #   assert_equal "Dazu hast du keine Berechtigung.", flash[:notice]
-  # end
-
   # --- Reservations: viewing is open to all roles ----------------------------
 
-  # test "every role may view the reservation list" do
-  #   %i[owner member external shared_account].each do |role|
-  #     sign_in_as(role)
-  #     get root_path
-  #     assert_response :success
-  #   end
-  # end
+  test "every role may view the reservation list" do
+    %i[owner member external shared_account].each do |role|
+      sign_in_as(role)
+      get root_path
 
-  # test "external and shared_account may view a single reservation" do
-  #   owner = create(:user, role: :owner)
-  #   reservation = Reservation.create!(reservation_attrs(owner))
-  #   %i[external shared_account].each do |role|
-  #     sign_in_as(role)
-  #     get reservation_path(reservation)
-  #     assert_response :success
-  #   end
-  # end
+      assert_response :success
+    end
+  end
+
+  test "external and shared_account may view a single reservation" do
+    owner = create(:user, role: :owner)
+    reservation = Reservation.create!(reservation_attrs(owner))
+    %i[external shared_account].each do |role|
+      sign_in_as(role)
+      get reservation_path(reservation)
+
+      assert_response :success
+    end
+  end
 
   # --- Reservations: creating/editing restricted to owner + member -----------
 
-  # test "external cannot reach the new-reservation form" do
-  #   sign_in_as(:external)
-  #   get new_reservation_path
-  #   assert_forbidden
-  # end
+  test "external cannot reach the new-reservation form" do
+    sign_in_as(:external)
+    get new_reservation_path
 
-  # test "shared_account cannot create a reservation" do
-  #   user = sign_in_as(:shared_account)
-  #   assert_no_difference -> { Reservation.count } do
-  #     post reservations_path, params: { reservation: reservation_attrs(user) }
-  #   end
-  #   assert_forbidden
-  # end
+    assert_forbidden
+  end
 
-  # test "external cannot edit or destroy a reservation" do
-  #   owner = create(:user, role: :owner)
-  #   reservation = Reservation.create!(reservation_attrs(owner))
-  #   sign_in_as(:external)
-  #   get edit_reservation_path(reservation)
-  #   assert_forbidden
-  #   delete reservation_path(reservation)
-  #   assert_forbidden
-  #   assert Reservation.exists?(reservation.id)
-  # end
+  test "shared_account cannot create a reservation" do
+    user = sign_in_as(:shared_account)
+
+    assert_no_difference -> { Reservation.count } do
+      post reservations_path, params: { reservation: reservation_attrs(user) }
+    end
+    assert_forbidden
+  end
+
+  test "external cannot edit or destroy a reservation" do
+    owner = create(:user, role: :owner)
+    reservation = Reservation.create!(reservation_attrs(owner))
+    sign_in_as(:external)
+
+    get edit_reservation_path(reservation)
+
+    assert_forbidden
+
+    delete reservation_path(reservation)
+
+    assert_forbidden
+    assert Reservation.exists?(reservation.id)
+  end
 
   # --- Reservations: member is confined to their own ------------------------
 
-  # test "member creating a reservation is forced onto their own user_id" do
-  #   member = sign_in_as(:member)
-  #   other = create(:user, role: :owner)
-  #   post reservations_path, params: { reservation: reservation_attrs(member, user_id: other.id) }
-  #   assert_equal member, Reservation.last.user
-  # end
+  test "member creating a reservation is forced onto their own user_id" do
+    member = sign_in_as(:member)
+    other = create(:user, role: :owner)
+    post reservations_path, params: { reservation: reservation_attrs(member, user_id: other.id) }
 
-  # test "member cannot edit a foreign reservation" do
-  #   owner = create(:user, role: :owner)
-  #   reservation = Reservation.create!(reservation_attrs(owner))
-  #   sign_in_as(:member)
-  #   patch reservation_path(reservation), params: { reservation: { comment: "hijack" } }
-  #   assert_forbidden
-  #   assert_not_equal "hijack", reservation.reload.comment
-  # end
+    assert_equal member, Reservation.last.user
+  end
 
-  # test "member cannot destroy a foreign reservation" do
-  #   owner = create(:user, role: :owner)
-  #   reservation = Reservation.create!(reservation_attrs(owner))
-  #   sign_in_as(:member)
-  #   delete reservation_path(reservation)
-  #   assert_forbidden
-  #   assert Reservation.exists?(reservation.id)
-  # end
+  test "member cannot edit a foreign reservation" do
+    owner = create(:user, role: :owner)
+    reservation = Reservation.create!(reservation_attrs(owner))
+    sign_in_as(:member)
+    patch reservation_path(reservation), params: { reservation: { comment: "hijack" } }
+
+    assert_forbidden
+    assert_not_equal "hijack", reservation.reload.comment
+  end
+
+  test "member cannot destroy a foreign reservation" do
+    owner = create(:user, role: :owner)
+    reservation = Reservation.create!(reservation_attrs(owner))
+    sign_in_as(:member)
+    delete reservation_path(reservation)
+
+    assert_forbidden
+    assert Reservation.exists?(reservation.id)
+  end
 
   # --- Reservations: owner is admin-like ------------------------------------
 
-  # test "owner can create a reservation for another user" do
-  #   sign_in_as(:owner)
-  #   member = create(:user, role: :member)
-  #   post reservations_path, params: { reservation: reservation_attrs(member) }
-  #   assert_equal member, Reservation.last.user
-  # end
+  test "owner can create a reservation for another user" do
+    sign_in_as(:owner)
+    member = create(:user, role: :member)
+    post reservations_path, params: { reservation: reservation_attrs(member) }
 
-  # test "owner can edit and destroy a foreign reservation" do
-  #   member = create(:user, role: :member)
-  #   reservation = Reservation.create!(reservation_attrs(member))
-  #   sign_in_as(:owner)
-  #   patch reservation_path(reservation), params: { reservation: { comment: "fixed" } }
-  #   assert_equal "fixed", reservation.reload.comment
-  #   delete reservation_path(reservation)
-  #   assert_not Reservation.exists?(reservation.id)
-  # end
+    assert_equal member, Reservation.last.user
+  end
+
+  test "owner can edit and destroy a foreign reservation" do
+    member = create(:user, role: :member)
+    reservation = Reservation.create!(reservation_attrs(member))
+    sign_in_as(:owner)
+
+    patch reservation_path(reservation), params: { reservation: { comment: "fixed" } }
+
+    assert_equal "fixed", reservation.reload.comment
+
+    delete reservation_path(reservation)
+
+    assert_not Reservation.exists?(reservation.id)
+  end
 
   # --- User management: reading the list vs. managing users ------------------
 
-  # test "member and shared_account may read the user list" do
-  #   %i[member shared_account].each do |role|
-  #     sign_in_as(role)
-  #     get users_path
-  #     assert_response :success
-  #   end
-  # end
+  test "member and shared_account may read the user list" do
+    %i[member shared_account].each do |role|
+      sign_in_as(role)
+      get users_path
 
-  # test "external cannot read the user list" do
-  #   sign_in_as(:external)
-  #   get users_path
-  #   assert_forbidden
-  # end
+      assert_response :success
+    end
+  end
 
-  # test "non-owners cannot create or destroy users" do
-  #   %i[member external shared_account].each do |role|
-  #     sign_in_as(role)
-  #     get new_user_path
-  #     assert_forbidden
-  #     other = create(:user, role: :member)
-  #     delete user_path(other)
-  #     assert_forbidden
-  #     assert User.exists?(other.id)
-  #   end
-  # end
+  test "external cannot read the user list" do
+    sign_in_as(:external)
+    get users_path
 
-  # test "owner can manage users" do
-  #   sign_in_as(:owner)
-  #   get users_path
-  #   assert_response :success
-  #   assert_difference -> { User.count }, 1 do
-  #     post users_path, params: { user: { name: "Neu", email: "neu@example.com", password: "password", role: "member" } }
-  #   end
-  # end
+    assert_forbidden
+  end
+
+  test "non-owners cannot create users" do
+    %i[member external shared_account].each do |role|
+      sign_in_as(role)
+
+      assert_no_difference -> { User.count } do
+        post users_path, params: { user: { name: "X", email: "x@example.com", password: "password", role: "member" } }
+      end
+      assert_forbidden
+    end
+  end
+
+  test "non-owners cannot destroy users" do
+    %i[member external shared_account].each do |role|
+      sign_in_as(role)
+      other = create(:user, role: :member)
+      delete user_path(other)
+
+      assert_forbidden
+      assert User.exists?(other.id)
+    end
+  end
+
+  test "owner can manage users" do
+    sign_in_as(:owner)
+    get users_path
+
+    assert_response :success
+
+    assert_difference -> { User.count }, 1 do
+      post users_path, params: { user: { name: "Neu", email: "neu@example.com", password: "password", role: "member" } }
+    end
+  end
 
   # --- User management: self-service for one's own account -------------------
 
-  # test "a member may edit and update their own account" do
-  #   member = sign_in_as(:member)
-  #   get edit_user_path(member)
-  #   assert_response :success
-  #   patch user_path(member), params: { user: { telefon: "079" } }
-  #   assert_equal "079", member.reload.telefon
-  # end
+  test "a member may edit and update their own account" do
+    member = sign_in_as(:member)
+    get edit_user_path(member)
 
-  # test "a member cannot edit another user's account" do
-  #   other = create(:user, role: :member)
-  #   sign_in_as(:member)
-  #   get edit_user_path(other)
-  #   assert_forbidden
-  # end
+    assert_response :success
 
-  # test "a member cannot escalate their own role" do
-  #   member = sign_in_as(:member)
-  #   patch user_path(member), params: { user: { role: "owner" } }
-  #   assert_not member.reload.owner?
-  # end
+    patch user_path(member), params: { user: { telefon: "079" } }
+
+    assert_equal "079", member.reload.telefon
+  end
+
+  test "a member cannot edit another user's account" do
+    other = create(:user, role: :member)
+    sign_in_as(:member)
+    get edit_user_path(other)
+
+    assert_forbidden
+  end
+
+  test "a member cannot update another user's account" do
+    other = create(:user, role: :member, telefon: "000")
+    sign_in_as(:member)
+    patch user_path(other), params: { user: { telefon: "999" } }
+
+    assert_forbidden
+    assert_equal "000", other.reload.telefon
+  end
+
+  test "a member cannot escalate their own role" do
+    member = sign_in_as(:member)
+    patch user_path(member), params: { user: { role: "owner" } }
+
+    assert_not member.reload.owner?
+  end
 
   # --- Password: every authenticated user manages their own ------------------
 
-  # test "an external user can change their own password" do
-  #   sign_in_as(:external)
-  #   patch password_path, params: { old_password: "password", user: { password: "newsecret", password_confirmation: "newsecret" } }
-  #   assert_redirected_to users_path
-  # end
+  test "an external user can change their own password" do
+    sign_in_as(:external)
+    patch password_path, params: { old_password: "password", user: { password: "newsecret", password_confirmation: "newsecret" } }
+
+    assert_redirected_to users_path
+  end
 
   # --- Abrechnung: owner + member + shared_account, not external -------------
 
-  # test "owner, member and shared_account may open the Abrechnung" do
-  #   %i[owner member shared_account].each do |role|
-  #     sign_in_as(role)
-  #     get abrechnung_jahresstatistik_url
-  #     assert_response :success
-  #   end
-  # end
+  test "owner, member and shared_account may open the Abrechnung" do
+    %i[owner member shared_account].each do |role|
+      sign_in_as(role)
+      get abrechnung_jahresstatistik_url
 
-  # test "external cannot open the Abrechnung" do
-  #   sign_in_as(:external)
-  #   get abrechnung_jahresstatistik_url
-  #   assert_forbidden
-  # end
+      assert_response :success
+    end
+  end
+
+  test "external cannot open the Abrechnung" do
+    sign_in_as(:external)
+    get abrechnung_jahresstatistik_url
+
+    assert_forbidden
+  end
+
+  private
+
+  def sign_in_as(role)
+    attrs = { role: role, password: "password" }
+    attrs[:responsible_user] = create(:user, role: :owner) if role == :external
+    user = create(:user, **attrs)
+    post session_path, params: { name: user.name, password: "password" }
+    user
+  end
+
+  def reservation_attrs(user, overrides = {})
+    {
+      user_id: user.id,
+      start: at("2019-03-01 14:00"),
+      finish: at("2019-03-01 18:00"),
+      type_of_reservation: Reservation::KURZAUFENTHALT,
+      is_exclusive: true,
+      comment: ""
+    }.merge(overrides)
+  end
+
+  def assert_forbidden
+    assert_redirected_to root_path
+    assert_equal "Dazu hast du keine Berechtigung.", flash[:notice]
+  end
 end

--- a/test/integration/role_authorization_test.rb
+++ b/test/integration/role_authorization_test.rb
@@ -1,0 +1,214 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+# Authorization spec for Vorhaben #1 (Rollen-Modell). See roles-spec.local.md
+# §5 for the access matrix this file encodes.
+#
+# Every test below is commented out so the suite stays green until the role
+# enum and the controller guards are implemented. Activate the relevant block
+# per Feinplanungs-Schritt, then run the broad suite.
+#
+# The expected behaviour for a forbidden action (spec §5, O-2) is a redirect to
+# root with a German flash; the exact wording below is illustrative and gets
+# pinned when the guard is built.
+class RoleAuthorizationTest < ActionDispatch::IntegrationTest
+  # def sign_in_as(role)
+  #   user = create(:user, role: role, password: "password")
+  #   post session_path, params: { name: user.name, password: "password" }
+  #   user
+  # end
+
+  # def reservation_attrs(user, overrides = {})
+  #   {
+  #     user_id: user.id,
+  #     start: at("2019-03-01 14:00"),
+  #     finish: at("2019-03-01 18:00"),
+  #     type_of_reservation: Reservation::KURZAUFENTHALT,
+  #     is_exclusive: true,
+  #     comment: ""
+  #   }.merge(overrides)
+  # end
+
+  # def assert_forbidden
+  #   assert_redirected_to root_path
+  #   assert_equal "Dazu hast du keine Berechtigung.", flash[:notice]
+  # end
+
+  # --- Reservations: viewing is open to all roles ----------------------------
+
+  # test "every role may view the reservation list" do
+  #   %i[owner member external shared_account].each do |role|
+  #     sign_in_as(role)
+  #     get root_path
+  #     assert_response :success
+  #   end
+  # end
+
+  # test "external and shared_account may view a single reservation" do
+  #   owner = create(:user, role: :owner)
+  #   reservation = Reservation.create!(reservation_attrs(owner))
+  #   %i[external shared_account].each do |role|
+  #     sign_in_as(role)
+  #     get reservation_path(reservation)
+  #     assert_response :success
+  #   end
+  # end
+
+  # --- Reservations: creating/editing restricted to owner + member -----------
+
+  # test "external cannot reach the new-reservation form" do
+  #   sign_in_as(:external)
+  #   get new_reservation_path
+  #   assert_forbidden
+  # end
+
+  # test "shared_account cannot create a reservation" do
+  #   user = sign_in_as(:shared_account)
+  #   assert_no_difference -> { Reservation.count } do
+  #     post reservations_path, params: { reservation: reservation_attrs(user) }
+  #   end
+  #   assert_forbidden
+  # end
+
+  # test "external cannot edit or destroy a reservation" do
+  #   owner = create(:user, role: :owner)
+  #   reservation = Reservation.create!(reservation_attrs(owner))
+  #   sign_in_as(:external)
+  #   get edit_reservation_path(reservation)
+  #   assert_forbidden
+  #   delete reservation_path(reservation)
+  #   assert_forbidden
+  #   assert Reservation.exists?(reservation.id)
+  # end
+
+  # --- Reservations: member is confined to their own ------------------------
+
+  # test "member creating a reservation is forced onto their own user_id" do
+  #   member = sign_in_as(:member)
+  #   other = create(:user, role: :owner)
+  #   post reservations_path, params: { reservation: reservation_attrs(member, user_id: other.id) }
+  #   assert_equal member, Reservation.last.user
+  # end
+
+  # test "member cannot edit a foreign reservation" do
+  #   owner = create(:user, role: :owner)
+  #   reservation = Reservation.create!(reservation_attrs(owner))
+  #   sign_in_as(:member)
+  #   patch reservation_path(reservation), params: { reservation: { comment: "hijack" } }
+  #   assert_forbidden
+  #   assert_not_equal "hijack", reservation.reload.comment
+  # end
+
+  # test "member cannot destroy a foreign reservation" do
+  #   owner = create(:user, role: :owner)
+  #   reservation = Reservation.create!(reservation_attrs(owner))
+  #   sign_in_as(:member)
+  #   delete reservation_path(reservation)
+  #   assert_forbidden
+  #   assert Reservation.exists?(reservation.id)
+  # end
+
+  # --- Reservations: owner is admin-like ------------------------------------
+
+  # test "owner can create a reservation for another user" do
+  #   sign_in_as(:owner)
+  #   member = create(:user, role: :member)
+  #   post reservations_path, params: { reservation: reservation_attrs(member) }
+  #   assert_equal member, Reservation.last.user
+  # end
+
+  # test "owner can edit and destroy a foreign reservation" do
+  #   member = create(:user, role: :member)
+  #   reservation = Reservation.create!(reservation_attrs(member))
+  #   sign_in_as(:owner)
+  #   patch reservation_path(reservation), params: { reservation: { comment: "fixed" } }
+  #   assert_equal "fixed", reservation.reload.comment
+  #   delete reservation_path(reservation)
+  #   assert_not Reservation.exists?(reservation.id)
+  # end
+
+  # --- User management: reading the list vs. managing users ------------------
+
+  # test "member and shared_account may read the user list" do
+  #   %i[member shared_account].each do |role|
+  #     sign_in_as(role)
+  #     get users_path
+  #     assert_response :success
+  #   end
+  # end
+
+  # test "external cannot read the user list" do
+  #   sign_in_as(:external)
+  #   get users_path
+  #   assert_forbidden
+  # end
+
+  # test "non-owners cannot create or destroy users" do
+  #   %i[member external shared_account].each do |role|
+  #     sign_in_as(role)
+  #     get new_user_path
+  #     assert_forbidden
+  #     other = create(:user, role: :member)
+  #     delete user_path(other)
+  #     assert_forbidden
+  #     assert User.exists?(other.id)
+  #   end
+  # end
+
+  # test "owner can manage users" do
+  #   sign_in_as(:owner)
+  #   get users_path
+  #   assert_response :success
+  #   assert_difference -> { User.count }, 1 do
+  #     post users_path, params: { user: { name: "Neu", email: "neu@example.com", password: "password", role: "member" } }
+  #   end
+  # end
+
+  # --- User management: self-service for one's own account -------------------
+
+  # test "a member may edit and update their own account" do
+  #   member = sign_in_as(:member)
+  #   get edit_user_path(member)
+  #   assert_response :success
+  #   patch user_path(member), params: { user: { telefon: "079" } }
+  #   assert_equal "079", member.reload.telefon
+  # end
+
+  # test "a member cannot edit another user's account" do
+  #   other = create(:user, role: :member)
+  #   sign_in_as(:member)
+  #   get edit_user_path(other)
+  #   assert_forbidden
+  # end
+
+  # test "a member cannot escalate their own role" do
+  #   member = sign_in_as(:member)
+  #   patch user_path(member), params: { user: { role: "owner" } }
+  #   assert_not member.reload.owner?
+  # end
+
+  # --- Password: every authenticated user manages their own ------------------
+
+  # test "an external user can change their own password" do
+  #   sign_in_as(:external)
+  #   patch password_path, params: { old_password: "password", user: { password: "newsecret", password_confirmation: "newsecret" } }
+  #   assert_redirected_to users_path
+  # end
+
+  # --- Abrechnung: owner + member + shared_account, not external -------------
+
+  # test "owner, member and shared_account may open the Abrechnung" do
+  #   %i[owner member shared_account].each do |role|
+  #     sign_in_as(role)
+  #     get abrechnung_jahresstatistik_url
+  #     assert_response :success
+  #   end
+  # end
+
+  # test "external cannot open the Abrechnung" do
+  #   sign_in_as(:external)
+  #   get abrechnung_jahresstatistik_url
+  #   assert_forbidden
+  # end
+end

--- a/test/models/reservation_test.rb
+++ b/test/models/reservation_test.rb
@@ -322,6 +322,23 @@ class ReservationTest < ActiveSupport::TestCase
     assert_equal 3, r.duration_in_8_hour_blocks
   end
 
+  test "editable_by? lets an owner edit any reservation" do
+    owner = create(:user, role: :owner)
+    foreign = create(:reservation, user: create(:user, role: :member))
+
+    assert foreign.editable_by?(owner)
+  end
+
+  test "editable_by? lets a member edit only their own reservation" do
+    member = create(:user, role: :member)
+    own = create(:reservation, user: member)
+    foreign = create(:reservation, user: create(:user, role: :member),
+                                   start: at("2019-02-05 14:00"), finish: at("2019-02-05 18:00"))
+
+    assert own.editable_by?(member)
+    assert_not foreign.editable_by?(member)
+  end
+
   test "paid_blocks gives co-owners six free blocks on non-exclusive stays" do
     stefan = create(:user, name: "Stefan")
     ruth   = create(:user, name: "Ruth", role: :owner)

--- a/test/models/reservation_test.rb
+++ b/test/models/reservation_test.rb
@@ -324,7 +324,7 @@ class ReservationTest < ActiveSupport::TestCase
 
   test "paid_blocks gives co-owners six free blocks on non-exclusive stays" do
     stefan = create(:user, name: "Stefan")
-    ruth   = create(:user, name: "Ruth", miteigentuemer: true)
+    ruth   = create(:user, name: "Ruth", role: :owner)
     seven_block_stay = lambda do |user, exclusive|
       Reservation.new(start: at("2010-06-01 14:00"), finish: at("2010-06-03 15:00"),
                       type_of_reservation: Reservation::KURZAUFENTHALT, user: user, is_exclusive: exclusive)
@@ -338,7 +338,7 @@ class ReservationTest < ActiveSupport::TestCase
 
   test "billed_fee depends on the reservation type" do
     stefan = create(:user, name: "Stefan")
-    ruth   = create(:user, name: "Ruth", miteigentuemer: true)
+    ruth   = create(:user, name: "Ruth", role: :owner)
 
     r = Reservation.new(start: at("2010-06-01 14:00"), finish: at("2010-06-03 14:00"),
                         type_of_reservation: Reservation::KURZAUFENTHALT, user: ruth, is_exclusive: false)

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -188,6 +188,53 @@ class UserTest < ActiveSupport::TestCase
     assert User.exists?(user.id)
   end
 
+  # --- role model (Vorhaben #1, pending) -------------------------------------
+  # Spec: roles-spec.local.md §2, §3. Commented out until the role enum and
+  # responsible_user association exist; activate per Feinplanungs-Schritt.
+
+  # test "a new user defaults to the member role" do
+  #   assert_predicate build(:user), :member?
+  # end
+
+  # test "role predicates reflect the assigned role" do
+  #   assert_predicate build(:user, role: :owner), :owner?
+  #   assert_not build(:user, role: :owner).member?
+  # end
+
+  # test "role_label returns the German label" do
+  #   assert_equal "Miteigentümer/in", build(:user, role: :owner).role_label
+  #   assert_equal "Haus-Login", build(:user, role: :shared_account).role_label
+  # end
+
+  # test "ROLE_LABELS covers every enum role" do
+  #   assert_equal User.roles.keys.sort, User::ROLE_LABELS.keys.map(&:to_s).sort
+  # end
+
+  # test "an external user requires a responsible owner" do
+  #   external = build(:user, role: :external, responsible_user: nil)
+  #   assert_not external.valid?
+  #   assert_predicate external.errors[:responsible_user], :present?
+  # end
+
+  # test "the responsible user must itself be an owner" do
+  #   member = create(:user, role: :member)
+  #   external = build(:user, role: :external, responsible_user: member)
+  #   assert_not external.valid?
+  # end
+
+  # test "an external user with a responsible owner is valid" do
+  #   owner = create(:user, role: :owner)
+  #   external = build(:user, role: :external, responsible_user: owner)
+  #   assert_predicate external, :valid?
+  # end
+
+  # test "non-external roles must not have a responsible user" do
+  #   owner = create(:user, role: :owner)
+  #   member = build(:user, role: :member, responsible_user: owner)
+  #   assert_not member.valid?
+  #   assert_predicate member.errors[:responsible_user], :present?
+  # end
+
   private
 
   def make_legacy_user(password, salt: "legacy-salt")

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -8,7 +8,6 @@
 #  email                  :string(255)
 #  has_to_change_password :boolean
 #  hashed_password        :string(255)
-#  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
 #  role                   :string(255)      default("member"), not null
@@ -195,7 +194,7 @@ class UserTest < ActiveSupport::TestCase
     assert User.exists?(user.id)
   end
 
-  # --- role model (Vorhaben #1) ----------------------------------------------
+  # --- role model ------------------------------------------------------------
 
   test "a new user defaults to the member role" do
     assert_predicate build(:user), :member?

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -11,15 +11,22 @@
 #  miteigentuemer         :boolean
 #  name                   :string(255)
 #  password_digest        :string(255)
+#  role                   :string(255)      default("member"), not null
 #  salt                   :string(255)
 #  telefon                :string(255)
 #  created_at             :datetime         not null
 #  updated_at             :datetime         not null
+#  responsible_user_id    :bigint
 #
 # Indexes
 #
-#  index_users_on_email  (email) UNIQUE
-#  index_users_on_name   (name) UNIQUE
+#  index_users_on_email                (email) UNIQUE
+#  index_users_on_name                 (name) UNIQUE
+#  index_users_on_responsible_user_id  (responsible_user_id)
+#
+# Foreign Keys
+#
+#  fk_rails_...  (responsible_user_id => users.id)
 #
 
 require "test_helper"
@@ -188,52 +195,54 @@ class UserTest < ActiveSupport::TestCase
     assert User.exists?(user.id)
   end
 
-  # --- role model (Vorhaben #1, pending) -------------------------------------
-  # Spec: roles-spec.local.md §2, §3. Commented out until the role enum and
-  # responsible_user association exist; activate per Feinplanungs-Schritt.
+  # --- role model (Vorhaben #1) ----------------------------------------------
 
-  # test "a new user defaults to the member role" do
-  #   assert_predicate build(:user), :member?
-  # end
+  test "a new user defaults to the member role" do
+    assert_predicate build(:user), :member?
+  end
 
-  # test "role predicates reflect the assigned role" do
-  #   assert_predicate build(:user, role: :owner), :owner?
-  #   assert_not build(:user, role: :owner).member?
-  # end
+  test "role predicates reflect the assigned role" do
+    assert_predicate build(:user, role: :owner), :owner?
+    assert_not build(:user, role: :owner).member?
+  end
 
-  # test "role_label returns the German label" do
-  #   assert_equal "Miteigentümer/in", build(:user, role: :owner).role_label
-  #   assert_equal "Haus-Login", build(:user, role: :shared_account).role_label
-  # end
+  test "role_label returns the German label" do
+    assert_equal "Miteigentümer/in", build(:user, role: :owner).role_label
+    assert_equal "Haus-Login", build(:user, role: :shared_account).role_label
+  end
 
-  # test "ROLE_LABELS covers every enum role" do
-  #   assert_equal User.roles.keys.sort, User::ROLE_LABELS.keys.map(&:to_s).sort
-  # end
+  test "ROLE_LABELS covers every enum role" do
+    assert_equal User.roles.keys.sort, User::ROLE_LABELS.keys.map(&:to_s).sort
+  end
 
-  # test "an external user requires a responsible owner" do
-  #   external = build(:user, role: :external, responsible_user: nil)
-  #   assert_not external.valid?
-  #   assert_predicate external.errors[:responsible_user], :present?
-  # end
+  test "an external user requires a responsible owner" do
+    external = build(:user, role: :external, responsible_user: nil)
 
-  # test "the responsible user must itself be an owner" do
-  #   member = create(:user, role: :member)
-  #   external = build(:user, role: :external, responsible_user: member)
-  #   assert_not external.valid?
-  # end
+    assert_not external.valid?
+    assert_predicate external.errors[:responsible_user], :present?
+  end
 
-  # test "an external user with a responsible owner is valid" do
-  #   owner = create(:user, role: :owner)
-  #   external = build(:user, role: :external, responsible_user: owner)
-  #   assert_predicate external, :valid?
-  # end
+  test "the responsible user must itself be an owner" do
+    member = create(:user, role: :member)
+    external = build(:user, role: :external, responsible_user: member)
 
-  # test "non-external roles must not have a responsible user" do
-  #   owner = create(:user, role: :owner)
-  #   member = build(:user, role: :member, responsible_user: owner)
-  #   assert_not member.valid?
-  #   assert_predicate member.errors[:responsible_user], :present?
-  # end
+    assert_not external.valid?
+  end
+
+  test "an external user with a responsible owner is valid" do
+    owner = create(:user, role: :owner)
+    external = build(:user, role: :external, responsible_user: owner)
+
+    assert_predicate external, :valid?
+  end
+
+  test "non-external roles must not have a responsible user" do
+    owner = create(:user, role: :owner)
+    member = build(:user, role: :member, responsible_user: owner)
+
+    assert_not member.valid?
+    assert_predicate member.errors[:responsible_user], :present?
+  end
 
   private
 

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -210,6 +210,13 @@ class UserTest < ActiveSupport::TestCase
     assert_equal "Haus-Login", build(:user, role: :shared_account).role_label
   end
 
+  test "may_reserve? is true only for owners and members" do
+    assert_predicate build(:user, role: :owner), :may_reserve?
+    assert_predicate build(:user, role: :member), :may_reserve?
+    assert_not build(:user, role: :shared_account).may_reserve?
+    assert_not build(:user, role: :external).may_reserve?
+  end
+
   test "ROLE_LABELS covers every enum role" do
     assert_equal User.roles.keys.sort, User::ROLE_LABELS.keys.map(&:to_s).sort
   end

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -215,6 +215,11 @@ class UserTest < ActiveSupport::TestCase
     assert_equal User.roles.keys.sort, User::ROLE_LABELS.keys.map(&:to_s).sort
   end
 
+  test "external is not assignable until the responsible_user flow exists" do
+    assert_not_includes User::ASSIGNABLE_ROLE_LABELS.keys, "external"
+    assert_includes User::ROLE_LABELS.keys, "external"
+  end
+
   test "an external user requires a responsible owner" do
     external = build(:user, role: :external, responsible_user: nil)
 

--- a/test/services/reservation_billing_test.rb
+++ b/test/services/reservation_billing_test.rb
@@ -3,9 +3,9 @@
 require "test_helper"
 
 class ReservationBillingTest < ActiveSupport::TestCase
-  def billing(type:, blocks: 0, days: 0, miteigentuemer: false, exclusive: false)
+  def billing(type:, blocks: 0, days: 0, owner: false, exclusive: false)
     ReservationBilling.new(type: type, blocks: blocks, days: days,
-                           miteigentuemer: miteigentuemer, exclusive: exclusive)
+                           owner: owner, exclusive: exclusive)
   end
 
   test "short and long stays bill 15 CHF per block" do
@@ -22,19 +22,19 @@ class ReservationBillingTest < ActiveSupport::TestCase
   end
 
   test "co-owner gets the first 6 blocks free on non-exclusive stays" do
-    assert_equal 1, billing(blocks: 7, miteigentuemer: true, exclusive: false,
+    assert_equal 1, billing(blocks: 7, owner: true, exclusive: false,
                             type: Reservation::KURZAUFENTHALT).paid_blocks
-    assert_equal 0, billing(blocks: 6, miteigentuemer: true, exclusive: false,
+    assert_equal 0, billing(blocks: 6, owner: true, exclusive: false,
                             type: Reservation::KURZAUFENTHALT).paid_blocks
   end
 
   test "co-owner discount does not apply to exclusive stays" do
-    assert_equal 7, billing(blocks: 7, miteigentuemer: true, exclusive: true,
+    assert_equal 7, billing(blocks: 7, owner: true, exclusive: true,
                             type: Reservation::KURZAUFENTHALT).paid_blocks
   end
 
   test "non co-owner pays for every block" do
-    assert_equal 7, billing(blocks: 7, miteigentuemer: false, exclusive: false,
+    assert_equal 7, billing(blocks: 7, owner: false, exclusive: false,
                             type: Reservation::KURZAUFENTHALT).paid_blocks
   end
 end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -34,10 +34,15 @@ end
 
 class ActionDispatch::IntegrationTest
   # Creates a user and signs it in through the real login flow. Returns the
-  # user. Shared by the controller/integration tests (previously duplicated).
-  def login_as_user(name: "Session User", email: "session-user@example.com", password: "password")
-    user = create(:user, name: name, email: email, password: password)
+  # user. Defaults to a member; tests that need elevated rights call
+  # login_as_owner.
+  def login_as_user(name: "Session User", email: "session-user@example.com", password: "password", role: :member)
+    user = create(:user, name: name, email: email, password: password, role: role)
     post session_path, params: { name: name, password: password }
     user
+  end
+
+  def login_as_owner(**)
+    login_as_user(role: :owner, **)
   end
 end


### PR DESCRIPTION
Ersetzt das einzelne `miteigentuemer`-Boolean durch ein echtes Rollen-Modell
(owner / member / external / shared_account), das Grundlage für Login, Tarif
und Logbuch ist. Autorisierung von Hand, kein Gem.

Schritte (ein Commit je Schritt):

1. Modell — `role`-Enum (Backfill aus `miteigentuemer`), `responsible_user`,
   `ROLE_LABELS`/`role_label`, Validierungen.
2. Billing — Co-Owner-Rabatt zieht aus `owner?` statt dem Boolean.
3. Autorisierung — `Authorization`-Concern + Guards je Controller-Action
   gemäss Zugriffsmatrix (Redirect+Flash bei fehlender Berechtigung).
4. UI — Rollen-Select statt Checkbox; `:miteigentuemer` nicht mehr geschrieben.
5. Drop der Legacy-Spalte `miteigentuemer`.
6. Cleanup — Policy in `User#may_reserve?` / `Reservation#editable_by?` mit
   Unit-Tests.

`external` ist noch nicht im Rollen-Select wählbar (braucht den
`responsible_user`-Flow) — folgt im Login/User-Vorhaben.

Suite 152 runs grün, Brakeman sauber.