### PR TITLE
Render the user list as a table with action icons

### DIFF
--- a/app/assets/stylesheets/users.css
+++ b/app/assets/stylesheets/users.css
@@ -1,0 +1,131 @@
+/* Users module — the account list table and its row actions. */
+
+.user-table {
+	width: 100%;
+	border-collapse: collapse;
+	background: var(--card);
+	border: 1px solid var(--line);
+	border-radius: var(--radius);
+	overflow: hidden;
+}
+
+.user-table th,
+.user-table td {
+	padding: 0.6rem 0.85rem;
+	text-align: left;
+	border-bottom: 1px solid var(--line);
+	vertical-align: middle;
+	overflow-wrap: anywhere;
+}
+
+.user-table thead th {
+	background: #f4efe7;
+	font-size: 0.74rem;
+	font-weight: 600;
+	letter-spacing: 0.03em;
+	text-transform: uppercase;
+	color: var(--muted);
+}
+
+.user-table tbody tr:last-child td {
+	border-bottom: none;
+}
+
+.user-table tbody tr:hover {
+	background: var(--paper);
+}
+
+.user-table__actions {
+	width: 1%;
+	white-space: nowrap;
+}
+
+.user-actions {
+	display: flex;
+	gap: 0.35rem;
+}
+
+.icon-btn {
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	width: 2rem;
+	height: 2rem;
+	border-radius: 8px;
+	color: var(--muted);
+	text-decoration: none;
+}
+
+.icon-btn:hover {
+	background: #f0ece4;
+	color: var(--ink);
+	text-decoration: none;
+}
+
+.icon-btn--danger:hover {
+	background: #fce8e6;
+	color: #b3261e;
+}
+
+.icon-btn .icon {
+	width: 18px;
+	height: 18px;
+}
+
+.user-table__footer {
+	display: flex;
+	gap: 1.2rem;
+	margin-top: 1rem;
+}
+
+/* The flat table starts to break around 1000px; below that each row becomes a
+   card (capped narrow so it does not stretch empty on mid-size viewports):
+   name on top, the action icons in the top-right corner, the rest below. */
+@media (max-width: 1000px) {
+	.user-table {
+		max-width: 450px;
+	}
+
+	.user-table thead {
+		display: none;
+	}
+
+	.user-table tbody,
+	.user-table tr,
+	.user-table td {
+		display: block;
+	}
+
+	.user-table tr {
+		position: relative;
+		padding: 0.7rem 0.9rem;
+		border-bottom: 1px solid var(--line);
+	}
+
+	.user-table tbody tr:last-child {
+		border-bottom: none;
+	}
+
+	.user-table td {
+		padding: 0;
+		border: none;
+	}
+
+	.user-table__name {
+		font-weight: 600;
+		font-size: 1.05rem;
+		padding-right: 7rem;
+	}
+
+	.user-table__role {
+		color: var(--muted);
+		font-size: 0.86rem;
+		margin-bottom: 0.2rem;
+	}
+
+	.user-table__actions-cell {
+		position: absolute;
+		top: 0.6rem;
+		right: 0.7rem;
+	}
+}

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,6 +1,12 @@
 # frozen_string_literal: true
 
 module ApplicationHelper
+  # Renders an icon from the shared sprite (app/views/shared/_icon_sprite).
+  # The icon is decorative; the interactive parent carries the accessible name.
+  def icon(name)
+    content_tag(:svg, tag.use(href: "#icon-#{name}"), class: "icon", "aria-hidden": "true")
+  end
+
   def time_components_of(numeric)
     (reminder, secs) = numeric.divmod(60)
     (reminder, mins) = reminder.divmod(60)

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -6,7 +6,7 @@
     <%= csp_meta_tag %>
 
     <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%= stylesheet_link_tag "base", "layout", "calendar", "reservation", "overlay", "state", media: "all" %>
+    <%= stylesheet_link_tag "base", "layout", "calendar", "reservation", "overlay", "users", "state", media: "all" %>
     <%= javascript_importmap_tags %>
   </head>
 

--- a/app/views/layouts/reservation.html.erb
+++ b/app/views/layouts/reservation.html.erb
@@ -7,11 +7,12 @@
 
   <link rel="shortcut icon" type="image/x-icon" href="/favicon.ico">
   <meta name="viewport" content="width=device-width, initial-scale=1">
-    <%= stylesheet_link_tag "base", "layout", "calendar", "reservation", "overlay", "state", media: "all" %>
+    <%= stylesheet_link_tag "base", "layout", "calendar", "reservation", "overlay", "users", "state", media: "all" %>
     <%= javascript_importmap_tags %>
 
 </head>
 <body id="brueschhuesli-app">
+  <%= render "shared/icon_sprite" %>
 
   <header class="site-header" data-controller="navbar-toggle">
     <nav class="site-nav">

--- a/app/views/shared/_icon_sprite.html.erb
+++ b/app/views/shared/_icon_sprite.html.erb
@@ -1,0 +1,16 @@
+<svg width="0" height="0" class="is-hidden" aria-hidden="true">
+  <symbol id="icon-edit" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M12 20h9" />
+    <path d="M16.5 3.5a2.12 2.12 0 0 1 3 3L7 19l-4 1 1-4Z" />
+  </symbol>
+  <symbol id="icon-delete" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M3 6h18" />
+    <path d="M8 6V4a2 2 0 0 1 2-2h4a2 2 0 0 1 2 2v2" />
+    <path d="M19 6l-1 14a2 2 0 0 1-2 2H8a2 2 0 0 1-2-2L5 6" />
+    <path d="M10 11v6M14 11v6" />
+  </symbol>
+  <symbol id="icon-reservations" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="4" width="18" height="18" rx="2" />
+    <path d="M16 2v4M8 2v4M3 10h18" />
+  </symbol>
+</svg>

--- a/app/views/users/index.html.erb
+++ b/app/views/users/index.html.erb
@@ -1,15 +1,35 @@
 <h1>Benutzer</h1>
-<ul>
-  <% for user in @all_users %>
-    <li>
-      <%= h(user.name) %> 	(<%= user.role_label %>, <%= mail_to user.email %>, <%= user.telefon %>)
-      <small><i>
-      <%= link_to "[Bearbeiten]", edit_user_path(user) %>
-      <%= link_to "[Löschen]", user_path(user), data: { turbo_method: :delete, turbo_confirm: "#{user.name} wirklich löschen?" } %>
-      <%= link_to "[Reservationen]", controller: "abrechnung", action: "benutzer", id: user %>
-      </small></i>
-    </li>
-  <% end %>
-</ul>
-<%= link_to "Benutzer hinzufügen", new_user_path %><br>
-<%= link_to "Mein Passwort ändern", edit_password_path %>
+
+<table class="user-table">
+  <thead>
+    <tr>
+      <th>Name</th>
+      <th>Rolle</th>
+      <th>E-Mail</th>
+      <th>Telefon</th>
+      <th class="user-table__actions">Aktionen</th>
+    </tr>
+  </thead>
+  <tbody>
+    <% @all_users.each do |user| %>
+      <tr>
+        <td class="user-table__name"><%= h(user.name) %></td>
+        <td class="user-table__role"><%= user.role_label %></td>
+        <td><%= mail_to user.email %></td>
+        <td><%= user.telefon %></td>
+        <td class="user-table__actions-cell">
+          <div class="user-actions">
+            <%= link_to icon(:edit), edit_user_path(user), class: "icon-btn", title: "Bearbeiten", aria: { label: "#{user.name} bearbeiten" } %>
+            <%= link_to icon(:delete), user_path(user), class: "icon-btn icon-btn--danger", title: "Löschen", aria: { label: "#{user.name} löschen" }, data: { turbo_method: :delete, turbo_confirm: "#{user.name} wirklich löschen?" } %>
+            <%= link_to icon(:reservations), { controller: "abrechnung", action: "benutzer", id: user }, class: "icon-btn", title: "Reservationen", aria: { label: "Reservationen von #{user.name}" } %>
+          </div>
+        </td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<div class="user-table__footer">
+  <%= link_to "Benutzer hinzufügen", new_user_path %>
+  <%= link_to "Mein Passwort ändern", edit_password_path %>
+</div>


### PR DESCRIPTION
The /users page was a hard-to-scan bullet list, made worse by the
new colour scheme.

- Table layout: name, role, email, phone, actions.
- Edit/delete/reservations as idiomatic icons instead of bracketed
  text links.
- Below ~1000px the table collapses into a narrow card list, so it
  never overflows (verified down to 390px).
- SVGs extracted into a shared sprite partial + `icon` helper,
  reusable across views.